### PR TITLE
Report auth refresh failures to Sentry

### DIFF
--- a/playlist-manager-native/lib/auth.test.ts
+++ b/playlist-manager-native/lib/auth.test.ts
@@ -26,7 +26,13 @@ jest.mock('expo-auth-session', () => ({
 jest.mock('expo-web-browser', () => ({
   maybeCompleteAuthSession: jest.fn(),
 }));
+jest.mock('@sentry/react-native', () => ({
+  captureMessage: jest.fn(),
+  addBreadcrumb: jest.fn(),
+  captureException: jest.fn(),
+}));
 
+import * as Sentry from '@sentry/react-native';
 import {
   isTokenExpired,
   saveTokens,
@@ -35,6 +41,8 @@ import {
   getValidAccessToken,
   ReauthRequiredError,
 } from './auth';
+
+const mockedCaptureMessage = Sentry.captureMessage as jest.Mock;
 
 function jsonResponse(status: number, body: unknown): Response {
   return {
@@ -48,6 +56,7 @@ function jsonResponse(status: number, body: unknown): Response {
 beforeEach(() => {
   mockTokenStore = new Map();
   jest.restoreAllMocks();
+  jest.clearAllMocks();
 });
 
 describe('isTokenExpired', () => {
@@ -119,6 +128,22 @@ describe('refreshAccessToken', () => {
     global.fetch = jest.fn().mockResolvedValue(jsonResponse(401, { error: 'invalid_grant' }));
 
     await expect(refreshAccessToken('stale-token')).rejects.toBeInstanceOf(ReauthRequiredError);
+  });
+
+  it('reports the Auth0 error_description to Sentry on rejection', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      jsonResponse(401, { error: 'invalid_grant', error_description: 'The refresh token was already used' })
+    );
+
+    await expect(refreshAccessToken('stale-token')).rejects.toBeInstanceOf(ReauthRequiredError);
+
+    expect(mockedCaptureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('401'),
+      expect.objectContaining({
+        tags: expect.objectContaining({ auth0_error: 'invalid_grant' }),
+        extra: expect.objectContaining({ error_description: 'The refresh token was already used' })
+      })
+    );
   });
 
   it('throws ReauthRequiredError when Auth0 rejects the token (400)', async () => {

--- a/playlist-manager-native/lib/auth.ts
+++ b/playlist-manager-native/lib/auth.ts
@@ -18,6 +18,7 @@
 import * as AuthSession from 'expo-auth-session';
 import * as WebBrowser from 'expo-web-browser';
 import * as SecureStore from 'expo-secure-store';
+import * as Sentry from '@sentry/react-native';
 import { writeAuthToken } from '../modules/widget-bridge';
 
 WebBrowser.maybeCompleteAuthSession();
@@ -186,19 +187,30 @@ export async function refreshAccessToken(refreshToken: string): Promise<string> 
     });
 
     if (!response.ok) {
-      // Auth0 responds 400/401 when the refresh token itself is invalid,
-      // expired, or was rejected as already-rotated — the one case that
-      // genuinely requires the user to log in again. A 429 (rate limited)
-      // or 5xx (Auth0-side outage) means the token was never evaluated at
-      // all and must be treated as transient, not a rejection.
-      if (response.status === 400 || response.status === 401) {
-        throw new ReauthRequiredError(`Token refresh rejected: ${response.status} ${response.statusText}`);
+      // Auth0's response body carries the actual reason (error/error_description
+      // — e.g. "invalid_grant: The refresh token was already used" vs "Unknown
+      // or invalid refresh token" vs an inactivity/absolute expiry message).
+      // Without this, a forced logout is indistinguishable from any other in
+      // Sentry — this is the one place with enough context to tell them apart.
+      const body: { error?: string; error_description?: string } | null = await response.json().catch(() => null);
+      const reason = body?.error_description ?? body?.error ?? response.statusText;
+      const definitive = response.status === 400 || response.status === 401;
+
+      Sentry.captureMessage(`Auth0 refresh token request failed (${response.status})`, {
+        level: definitive ? 'warning' : 'error',
+        tags: { auth_refresh_status: String(response.status), auth0_error: body?.error ?? 'unknown' },
+        extra: { status: response.status, error_description: body?.error_description }
+      });
+
+      if (definitive) {
+        throw new ReauthRequiredError(`Token refresh rejected: ${response.status} ${reason}`);
       }
-      throw new Error(`Token refresh failed: ${response.status} ${response.statusText}`);
+      throw new Error(`Token refresh failed: ${response.status} ${reason}`);
     }
 
     const tokens = await response.json();
     await saveTokens(tokens);
+    Sentry.addBreadcrumb({ category: 'auth', message: 'Refreshed access token', level: 'info' });
     return tokens.access_token;
   })();
 
@@ -217,13 +229,25 @@ export async function refreshAccessToken(refreshToken: string): Promise<string> 
  */
 export async function getValidAccessToken(): Promise<string> {
   const stored = await getStoredTokens();
-  if (!stored?.accessToken) throw new ReauthRequiredError('Not authenticated');
+  if (!stored?.accessToken) {
+    // Distinct from the network-side failures captured in refreshAccessToken:
+    // this means SecureStore had nothing at all — never logged in, tokens
+    // cleared, or (if this ever recurs) something wiping the Keychain entry
+    // outside of clearTokens().
+    Sentry.captureMessage('getValidAccessToken: no stored access token', { level: 'warning' });
+    throw new ReauthRequiredError('Not authenticated');
+  }
 
   if (!isTokenExpired(stored.expiresAt)) {
     return stored.accessToken;
   }
 
-  if (!stored.refreshToken) throw new ReauthRequiredError('No refresh token — re-login required');
+  if (!stored.refreshToken) {
+    Sentry.captureMessage('getValidAccessToken: access token expired with no refresh token stored', {
+      level: 'warning'
+    });
+    throw new ReauthRequiredError('No refresh token — re-login required');
+  }
 
   try {
     return await refreshAccessToken(stored.refreshToken);


### PR DESCRIPTION
## Summary

Follow-up to #90 — the atomic-storage fix didn't stop the forced re-login after a few days backgrounded, so the torn-write theory doesn't fully explain it. Rather than keep guessing, this makes the next occurrence self-diagnosing.

A forced re-login was previously an entirely "expected" code path — `ReauthRequiredError` just routes to the login screen — and nothing about it was ever reported. That's exactly why Sentry showed zero issues for the auth project despite being wired up: there was nothing capturing the failure, only handling it gracefully.

## Changes

- `refreshAccessToken` now reads Auth0's actual response body on a failed refresh and reports `error`/`error_description` to Sentry — e.g. "The refresh token was already used" (rotation race) vs "Unknown or invalid refresh token" (corruption/staleness) vs an inactivity or absolute-expiry message (a tenant-side setting after all). That's the one piece of information that tells these apart, and until now nothing captured it. Reported at `warning` for a definitive 400/401 rejection, `error` for anything else (429/5xx), tagged by status and Auth0 error code so they're easy to filter/group in Sentry.
- A breadcrumb on every successful refresh, so a captured failure comes with timeline context (how long since the last successful refresh, how many happened before it).
- `getValidAccessToken`'s two no-network early exits — no stored access token at all, or an expired access token with no refresh token stored — are also reported, since they'd otherwise never reach the above (no HTTP call happens on those paths).

## Test plan
- [x] `npm run typecheck` / `npm run lint` clean
- [x] `npm test` — 18/18 passing, including a new test asserting the Sentry report actually carries Auth0's `error_description` through
- [ ] Manual: next time the forced re-login recurs, check the `playlist-manager-mobile` Sentry project for the captured message and its `error_description` — that'll tell us definitively what's actually happening

🤖 Generated with [Claude Code](https://claude.com/claude-code)