### PR TITLE
Discover played-from playlists mid-sync

### DIFF
--- a/playlist-manager-next/app/trigger/CLAUDE.md
+++ b/playlist-manager-next/app/trigger/CLAUDE.md
@@ -30,14 +30,21 @@ Per user, `syncForUser`:
 2. Finds the user's playlists whose name matches `NEW_ALBUMS_REGEX` (`app/utils/playlistFilters.ts`).
 3. `GET /me/player/recently-played` (limit 50), using `sync_log.last_played_at` as the
    `after` cursor. If >50 tracks played since last run, the overflow is lost (accepted).
-4. Resolves track → album → playlist in **one** Prisma query against data already synced
+4. `discoverPlayedPlaylists`: inspects the `context` of each play. Any playlist the user
+   played from that isn't in the DB yet and whose name matches `NEW_ALBUMS_REGEX` is
+   `addPlaylistToDb`'d right here, so a play from a just-created playlist records progress
+   on this same run instead of being lost when the cursor advances. Bounded to
+   `MAX_DISCOVERY_LOOKUPS` (5) Spotify lookups per run; failures are logged and skipped.
+   (A user with zero tracked playlists still returns early at step 2 and relies on the
+   on-open / weekly `refreshSpotifyPlaylists` to seed the first one.)
+5. Resolves track → album → playlist in **one** Prisma query against data already synced
    into Postgres — no extra Spotify calls, no N+1.
-5. Groups by `(album, playlist)`, keeping the highest track index seen, and upserts
+6. Groups by `(album, playlist)`, keeping the highest track index seen, and upserts
    `listening_progress` — **advance-only, never regresses `last_track_index`**
    (`source: 'recently_played'`).
-6. For each playlist that gained activity, fires `sync-playlist` (it self-throttles, so
+7. For each playlist that gained activity, fires `sync-playlist` (it self-throttles, so
    firing every run is safe).
-7. Advances the `sync_log` cursor to the newest `played_at`.
+8. Advances the `sync_log` cursor to the newest `played_at`.
 
 `maxDuration: 120`.
 

--- a/playlist-manager-next/app/trigger/syncRecentlyPlayed.ts
+++ b/playlist-manager-next/app/trigger/syncRecentlyPlayed.ts
@@ -4,6 +4,14 @@ import prisma from '../../lib/prisma';
 import { refreshSpotifyAccessToken } from '../api/spotify/utilities/refreshSpotifyAccessToken';
 import { NEW_ALBUMS_REGEX } from '../utils/playlistFilters';
 import { syncPlaylistTask } from './syncPlaylist';
+import { addPlaylistToDb } from '../api/playlists/[playlistId]/refresh/handler';
+
+/**
+ * Cap on how many unknown played-from playlists we'll look up per run (see
+ * discoverPlayedPlaylists). Bounds the wasted Spotify calls when a user listens
+ * to playlists we don't track (editorial mixes, friends' playlists, …).
+ */
+const MAX_DISCOVERY_LOOKUPS = 5;
 
 /**
  * syncRecentlyPlayed — runs every 15 minutes via Trigger.dev scheduler.
@@ -79,6 +87,10 @@ export async function syncForUser(user: { id: string; access_token: { refresh_to
   const activePlaylistIds = playlists.filter(p => NEW_ALBUMS_REGEX.test(p.name)).map(p => p.id);
 
   if (activePlaylistIds.length === 0) {
+    // No New Albums playlists in the DB yet — nothing to attribute progress to.
+    // The mid-sync discovery below needs at least one to get past this point;
+    // a user with zero tracked playlists relies on the on-open / weekly
+    // discovery in `refreshSpotifyPlaylists` to seed the first one.
     console.log('No New Albums playlists found, skipping', { userId: user.id });
     return;
   }
@@ -102,6 +114,14 @@ export async function syncForUser(user: { id: string; access_token: { refresh_to
   }
 
   console.log('Recently-played items fetched', { userId: user.id, count: items.length });
+
+  // ── Step 2.5: Discover newly-created playlists the user is already playing ───
+  // A play from a brand-new "New Albums DD/MM/YY" playlist created since the last
+  // discovery run won't match anything below — the playlist isn't in the DB yet.
+  // Spot those from the play context and add them now, so this same run records
+  // progress for them instead of losing the plays when the cursor advances.
+  const discoveredPlaylistIds = await discoverPlayedPlaylists(spotifySdk, user.id, items, playlists);
+  activePlaylistIds.push(...discoveredPlaylistIds);
 
   // ── Step 3: Batch-resolve track → album → playlist (single Prisma query) ────
   const trackIds = [...new Set(items.map(item => item.track?.id).filter((id): id is string => typeof id === 'string'))];
@@ -247,6 +267,56 @@ export async function syncForUser(user: { id: string; access_token: { refresh_to
   // items[0] is the most recent (Spotify returns newest first).
   const mostRecentPlayedAt = new Date(items[0].played_at);
   await updateSyncLog(user.id, mostRecentPlayedAt);
+}
+
+/**
+ * Look at where the user played tracks from. Any playlist context we don't
+ * already have in the DB, whose name matches NEW_ALBUMS_REGEX, is a
+ * just-created discovery playlist — add it (albums + tracks) so the caller can
+ * record progress for it on this same run. Returns the ids actually added.
+ *
+ * Bounded to MAX_DISCOVERY_LOOKUPS Spotify lookups per call; failures are logged
+ * and skipped (the on-open + weekly discovery remain the backstop).
+ */
+export async function discoverPlayedPlaylists(
+  spotifySdk: SpotifyApi,
+  userId: string,
+  items: Array<{ context?: { type?: string | null; uri?: string | null } | null }>,
+  knownPlaylists: { id: string }[]
+): Promise<string[]> {
+  const knownIds = new Set(knownPlaylists.map(p => p.id));
+
+  const unknownPlayedPlaylistIds = [
+    ...new Set(
+      items
+        .filter(item => item.context?.type === 'playlist')
+        .map(item => item.context?.uri?.split(':')[2])
+        .filter((id): id is string => typeof id === 'string' && id.length > 0)
+    )
+  ]
+    .filter(id => !knownIds.has(id))
+    .slice(0, MAX_DISCOVERY_LOOKUPS);
+
+  if (unknownPlayedPlaylistIds.length === 0) return [];
+
+  const added: string[] = [];
+  for (const playlistId of unknownPlayedPlaylistIds) {
+    try {
+      const spotifyPlaylist = await spotifySdk.playlists.getPlaylist(playlistId);
+      if (!NEW_ALBUMS_REGEX.test(spotifyPlaylist.name)) continue;
+
+      await addPlaylistToDb(spotifySdk, userId, spotifyPlaylist);
+      added.push(playlistId);
+      console.log('Discovered played-from playlist mid-sync', {
+        userId,
+        playlistId,
+        name: spotifyPlaylist.name
+      });
+    } catch (err) {
+      console.warn('Failed to add played-from playlist', { userId, playlistId, error: String(err) });
+    }
+  }
+  return added;
 }
 
 async function updateSyncLog(userId: string, lastPlayedAt: Date | null) {

--- a/playlist-manager-next/tests/app/trigger/syncRecentlyPlayed.test.ts
+++ b/playlist-manager-next/tests/app/trigger/syncRecentlyPlayed.test.ts
@@ -1,25 +1,29 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // vi.hoisted ensures these objects are initialised before vi.mock factories run.
-const { mockPrisma, mockGetRecentlyPlayedTracks, makeMockTask } = vi.hoisted(() => {
-  const mockGetRecentlyPlayedTracks = vi.fn();
-  const mockPrisma = {
-    user: { findMany: vi.fn() },
-    access_token: { findUnique: vi.fn() },
-    playlist: { findMany: vi.fn() },
-    sync_log: { findUnique: vi.fn(), upsert: vi.fn() },
-    track: { findMany: vi.fn() },
-    listening_progress: { findUnique: vi.fn(), upsert: vi.fn() }
-  };
-  const makeMockTask = (config: { id?: string; run: (payload: unknown, ctx: unknown) => Promise<void> }) => ({
-    // Expose run for testing (not part of real v4 API, but needed for unit tests)
-    run: config.run,
-    id: config.id || 'test-task',
-    trigger: vi.fn(),
-    triggerAndWait: vi.fn()
-  });
-  return { mockPrisma, mockGetRecentlyPlayedTracks, makeMockTask };
-});
+const { mockPrisma, mockGetRecentlyPlayedTracks, mockGetPlaylist, mockAddPlaylistToDb, makeMockTask } = vi.hoisted(
+  () => {
+    const mockGetRecentlyPlayedTracks = vi.fn();
+    const mockGetPlaylist = vi.fn();
+    const mockAddPlaylistToDb = vi.fn().mockResolvedValue(undefined);
+    const mockPrisma = {
+      user: { findMany: vi.fn() },
+      access_token: { findUnique: vi.fn() },
+      playlist: { findMany: vi.fn() },
+      sync_log: { findUnique: vi.fn(), upsert: vi.fn() },
+      track: { findMany: vi.fn() },
+      listening_progress: { findUnique: vi.fn(), upsert: vi.fn() }
+    };
+    const makeMockTask = (config: { id?: string; run: (payload: unknown, ctx: unknown) => Promise<void> }) => ({
+      // Expose run for testing (not part of real v4 API, but needed for unit tests)
+      run: config.run,
+      id: config.id || 'test-task',
+      trigger: vi.fn(),
+      triggerAndWait: vi.fn()
+    });
+    return { mockPrisma, mockGetRecentlyPlayedTracks, mockGetPlaylist, mockAddPlaylistToDb, makeMockTask };
+  }
+);
 
 vi.mock('../../../lib/prisma', () => ({ default: mockPrisma }));
 
@@ -37,13 +41,18 @@ vi.mock('@trigger.dev/sdk', () => ({
 vi.mock('@spotify/web-api-ts-sdk', () => ({
   SpotifyApi: {
     withAccessToken: vi.fn(() => ({
-      player: { getRecentlyPlayedTracks: mockGetRecentlyPlayedTracks }
+      player: { getRecentlyPlayedTracks: mockGetRecentlyPlayedTracks },
+      playlists: { getPlaylist: mockGetPlaylist }
     }))
   }
 }));
 
 vi.mock('../../../app/api/spotify/utilities/refreshSpotifyAccessToken', () => ({
   refreshSpotifyAccessToken: vi.fn().mockResolvedValue(undefined)
+}));
+
+vi.mock('../../../app/api/playlists/[playlistId]/refresh/handler', () => ({
+  addPlaylistToDb: mockAddPlaylistToDb
 }));
 
 import { syncRecentlyPlayedTask } from '../../../app/trigger/syncRecentlyPlayed';
@@ -76,9 +85,10 @@ const makeTrack = (id: string, albumId: string, trackNumber: number, totalTracks
   }
 });
 
-const makeRecentItem = (trackId: string, playedAt: string) => ({
+const makeRecentItem = (trackId: string, playedAt: string, contextPlaylistId?: string) => ({
   track: { id: trackId },
-  played_at: playedAt
+  played_at: playedAt,
+  context: contextPlaylistId ? { type: 'playlist', uri: `spotify:playlist:${contextPlaylistId}` } : null
 });
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -100,6 +110,8 @@ describe('syncRecentlyPlayedTask', () => {
     mockPrisma.sync_log.upsert.mockResolvedValue({});
     mockPrisma.listening_progress.findUnique.mockResolvedValue(null);
     mockPrisma.listening_progress.upsert.mockResolvedValue({});
+    mockPrisma.track.findMany.mockResolvedValue([]);
+    mockAddPlaylistToDb.mockResolvedValue(undefined);
   });
 
   it('does nothing when recently_played returns no items', async () => {
@@ -225,5 +237,89 @@ describe('syncRecentlyPlayedTask', () => {
     await expect(testTask.run(undefined as never, undefined as never)).resolves.not.toThrow();
 
     expect(mockGetRecentlyPlayedTracks).not.toHaveBeenCalled();
+  });
+
+  describe('discovering played-from playlists mid-sync', () => {
+    it('adds an unknown New Albums playlist from the play context and records its progress this run', async () => {
+      mockPrisma.playlist.findMany.mockResolvedValue([makePlaylist('pl-known', 'New Albums 01/01/26')]);
+      mockGetRecentlyPlayedTracks.mockResolvedValue({
+        items: [makeRecentItem('track-9', '2026-08-20T10:00:00Z', 'pl-new')]
+      });
+      mockGetPlaylist.mockResolvedValue({ id: 'pl-new', name: 'New Albums 20/08/26' });
+      mockPrisma.track.findMany.mockResolvedValue([makeTrack('track-9', 'album-9', 4, 10, 'pl-new')]);
+
+      await testTask.run(undefined as never, undefined as never);
+
+      expect(mockGetPlaylist).toHaveBeenCalledWith('pl-new');
+      expect(mockAddPlaylistToDb).toHaveBeenCalledWith(expect.anything(), 'user-1', {
+        id: 'pl-new',
+        name: 'New Albums 20/08/26'
+      });
+      expect(mockPrisma.listening_progress.upsert).toHaveBeenCalledOnce();
+      expect(mockPrisma.listening_progress.upsert.mock.calls[0][0].create.playlist_id).toBe('pl-new');
+    });
+
+    it('ignores an unknown played-from playlist whose name is not the New Albums format', async () => {
+      mockPrisma.playlist.findMany.mockResolvedValue([makePlaylist('pl-known', 'New Albums 01/01/26')]);
+      mockGetRecentlyPlayedTracks.mockResolvedValue({
+        items: [makeRecentItem('track-9', '2026-08-20T10:00:00Z', 'pl-editorial')]
+      });
+      mockGetPlaylist.mockResolvedValue({ id: 'pl-editorial', name: 'Discover Weekly' });
+
+      await testTask.run(undefined as never, undefined as never);
+
+      expect(mockAddPlaylistToDb).not.toHaveBeenCalled();
+    });
+
+    it('does not look up playlists already in the DB', async () => {
+      mockPrisma.playlist.findMany.mockResolvedValue([makePlaylist('pl-1', 'New Albums 04/04/26')]);
+      mockGetRecentlyPlayedTracks.mockResolvedValue({
+        items: [makeRecentItem('track-1', '2026-04-04T10:00:00Z', 'pl-1')]
+      });
+      mockPrisma.track.findMany.mockResolvedValue([makeTrack('track-1', 'album-1', 2, 12, 'pl-1')]);
+
+      await testTask.run(undefined as never, undefined as never);
+
+      expect(mockGetPlaylist).not.toHaveBeenCalled();
+    });
+
+    it('ignores plays with no playlist context', async () => {
+      mockPrisma.playlist.findMany.mockResolvedValue([makePlaylist('pl-1', 'New Albums 04/04/26')]);
+      mockGetRecentlyPlayedTracks.mockResolvedValue({
+        items: [makeRecentItem('track-1', '2026-04-04T10:00:00Z')]
+      });
+      mockPrisma.track.findMany.mockResolvedValue([makeTrack('track-1', 'album-1', 2, 12, 'pl-1')]);
+
+      await testTask.run(undefined as never, undefined as never);
+
+      expect(mockGetPlaylist).not.toHaveBeenCalled();
+    });
+
+    it('continues (and still advances the cursor) when a context lookup fails', async () => {
+      mockPrisma.playlist.findMany.mockResolvedValue([makePlaylist('pl-known', 'New Albums 01/01/26')]);
+      mockGetRecentlyPlayedTracks.mockResolvedValue({
+        items: [makeRecentItem('track-1', '2026-04-04T10:00:00Z', 'pl-broken')]
+      });
+      mockGetPlaylist.mockRejectedValue(new Error('Spotify 404'));
+
+      await expect(testTask.run(undefined as never, undefined as never)).resolves.not.toThrow();
+
+      expect(mockAddPlaylistToDb).not.toHaveBeenCalled();
+      expect(mockPrisma.sync_log.upsert).toHaveBeenCalled();
+    });
+
+    it('looks up at most MAX_DISCOVERY_LOOKUPS unknown played-from playlists per run', async () => {
+      mockPrisma.playlist.findMany.mockResolvedValue([makePlaylist('pl-known', 'New Albums 01/01/26')]);
+      mockGetRecentlyPlayedTracks.mockResolvedValue({
+        items: Array.from({ length: 8 }, (_, i) =>
+          makeRecentItem(`track-${i}`, `2026-08-20T10:0${i}:00Z`, `pl-unknown-${i}`)
+        )
+      });
+      mockGetPlaylist.mockResolvedValue({ id: 'x', name: 'Not Matching' });
+
+      await testTask.run(undefined as never, undefined as never);
+
+      expect(mockGetPlaylist).toHaveBeenCalledTimes(5);
+    });
   });
 });


### PR DESCRIPTION
Follow-up to #94 (item 1 of the two follow-ups discussed).

## Problem

If a user is **already listening** to a freshly-created "New Albums DD/MM/YY" playlist that hasn't been synced into the DB yet, `syncForUser` (recently-played sync) can't match those plays to any known playlist. The plays are silently dropped, and once the `sync_log` cursor advances past them they're gone for good — even after the playlist later gets discovered.

The on-open discovery from #94 only helps if it has run since the playlist was created (up to 12h lag); it doesn't help the "listening right now" case.

## Change

`syncForUser` now has a discovery step between fetching recently-played and resolving progress:

1. Collect the distinct playlist URIs from each play's `context` (`spotify:playlist:…`).
2. Drop any already in the user's DB.
3. For the rest (capped at `MAX_DISCOVERY_LOOKUPS` = 5 per run), fetch the playlist metadata; if the name matches `NEW_ALBUMS_REGEX`, `addPlaylistToDb(...)` it.
4. Add the new ids to `activePlaylistIds` so the **same run's** resolve pass records progress for them.

`addPlaylistToDb` also creates the album + track rows, so the resolve pass (which reads `track` / `album` / `playlistalbumrelationship`) finds everything with no re-pass needed.

### Bounds & failure handling

- Only fires Spotify calls for **unrecognised** playlist contexts — normal listening within known playlists costs nothing extra.
- Worst case (user only plays unknown editorial playlists): ≤ 5 metadata lookups per run.
- Any lookup/add failure is logged and skipped; the cursor still advances; on-open + weekly discovery remain the backstop.
- A user with **zero** tracked playlists still returns early (step 2) and relies on `refreshSpotifyPlaylists` to seed the first one — edge case, noted in code + `app/trigger/CLAUDE.md`.

## Testing

- `npm test` — 54 pass (6 new cases: discovers + records progress, ignores non-matching names, skips known playlists, ignores context-less plays, survives a failed lookup, respects the lookup cap)
- `npm run typecheck`, `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)